### PR TITLE
resolve TS2345 issue with SpellInfo

### DIFF
--- a/analysis/shamanelemental/src/modules/core/LavaSurge.tsx
+++ b/analysis/shamanelemental/src/modules/core/LavaSurge.tsx
@@ -1,4 +1,4 @@
-import SPELLS from 'common/SPELLS';
+import SPELLS from 'common/SPELLS/shaman';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';

--- a/analysis/shamanenhancement/src/modules/core/Stormbringer.tsx
+++ b/analysis/shamanenhancement/src/modules/core/Stormbringer.tsx
@@ -1,4 +1,4 @@
-import SPELLS from 'common/SPELLS';
+import SPELLS from 'common/SPELLS/shaman';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import Events, { DamageEvent } from 'parser/core/Events';

--- a/src/parser/core/EventFilter.ts
+++ b/src/parser/core/EventFilter.ts
@@ -4,8 +4,10 @@ export const SELECTED_PLAYER = 1;
 export const SELECTED_PLAYER_PET = 2;
 const VALID_BY_FLAGS = SELECTED_PLAYER | SELECTED_PLAYER_PET;
 
-export type SpellInfo = { id: number };
-export type SpellFilter = SpellInfo | SpellInfo[];
+export type SpellInfo = {
+  id: number;
+};
+export type SpellFilter<T extends SpellInfo = SpellInfo> = T | T[];
 
 class EventFilter<T extends EventType> {
   eventType: T;
@@ -36,7 +38,7 @@ class EventFilter<T extends EventType> {
     return this._to;
   }
   private _spell: SpellFilter | undefined;
-  spell(value: SpellFilter) {
+  spell<T extends SpellInfo = SpellInfo>(value: SpellFilter<T>) {
     // TODO: Use spell id instead
     if (typeof value !== 'object') {
       throw new Error('The spell filter must be a spell object, not a spell id.');


### PR DESCRIPTION
this re-enables the use of direct class SPELLS imports
like the below snippet:
```
import SPELLS from 'common/SPELLS/shaman';
```